### PR TITLE
feat: orbit_get_original_request func to get Unified Endpoint Original Request Message

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM emscripten/emsdk:4.0.0
+
+# Set the working directory
+WORKDIR /workspace
+
+# Set the default command to run when starting the container
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "C23 Emscripten Development",
+    "dockerFile": "Dockerfile",
+    "context": "..",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.cmake-tools"
+            ],
+            "settings": {
+                "C_Cpp.intelliSenseEngine": "Default",
+                "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
+            }
+        }
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "C_Cpp.default.cStandard": "c23",
+    "C_Cpp.default.cppStandard": "c++23",
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}/src",
+        "${workspaceFolder}/.devcontainer"
+    ],
+    "C_Cpp.errorSquiggles": "enabled"
+}

--- a/examples/gps-multi-unit/Makefile
+++ b/examples/gps-multi-unit/Makefile
@@ -16,7 +16,7 @@ $(output): $(objs)
 	$(MAKE) -C ../../soracom/
 
 main.o: main.cpp
-	emcc -I../../ -c main.cpp -o main.o
+	emcc -I../../ -std=c++23 -c main.cpp -o main.o
 
 .PHONY: clean
 clean:

--- a/examples/lte-m-button/Makefile
+++ b/examples/lte-m-button/Makefile
@@ -16,7 +16,7 @@ $(output): $(objs)
 	$(MAKE) -C ../../soracom/
 
 main.o: main.cpp
-	emcc -I../../ -c main.cpp -o main.o
+	emcc -I../../ -std=c++23 -c main.cpp -o main.o
 
 .PHONY: clean
 clean:

--- a/soracom/Makefile
+++ b/soracom/Makefile
@@ -1,5 +1,5 @@
 orbit.o:
-	emcc -c orbit.c -o orbit.o
+	emcc -std=c23 -c orbit.c -o orbit.o
 
 .PHONY: clean
 clean:

--- a/soracom/orbit.c
+++ b/soracom/orbit.c
@@ -67,17 +67,6 @@ int32_t soracom_get_input_buffer(const char** buf, size_t* siz) {
 }
 
 /**
- * Release the input buffer.
- *
- * @param buf [in] The pointer to the allocated input buffer.
- *
- * @note The pointer buf is allocated by either soracom_get_input_buffer() or soracom_get_input_buffer_as_string().
- */
-void soracom_release_input_buffer(const char* buf) {
-    free((void*)(buf));
-}
-
-/**
  * Get a tag value corresponding to the specified tag name.
  *
  * @param name [in] The name of the tag.
@@ -195,6 +184,20 @@ void soracom_release_buffer(const char* buf) {
  */
 [[deprecated("Use soracom_release_buffer instead")]]
 void soracom_release_userdata(const char* buf) {
+    soracom_release_buffer(buf);
+}
+
+
+/**
+ * Release the input buffer.
+ *
+ * @param buf [in] The pointer to the allocated input buffer.
+ *
+ * @note The pointer buf is allocated by either soracom_get_input_buffer() or soracom_get_input_buffer_as_string().
+ * @deprecated Use soracom_release_buffer instead
+ */
+[[deprecated("Use soracom_release_buffer instead")]]
+void soracom_release_input_buffer(const char* buf) {
     soracom_release_buffer(buf);
 }
 

--- a/soracom/orbit.c
+++ b/soracom/orbit.c
@@ -176,7 +176,7 @@ int32_t soracom_get_original_request_as_string(const char** buf, size_t* siz) {
  *
  * @param buf [in] The pointer to the allocated
  *
- * @note The pointer buf is allocated by 
+ * @note The pointer buf is allocated by
  * - soracom_get_userdata_as_string().
  * - soracom_get_original_request_as_string().
  */
@@ -191,8 +191,9 @@ void soracom_release_buffer(const char* buf) {
  *
  * @note The pointer buf is allocated by soracom_get_userdata_as_string().
  * @deprecated Use soracom_release_buffer instead
- * 
+ *
  */
+[[deprecated("Use soracom_release_buffer instead")]]
 void soracom_release_userdata(const char* buf) {
     soracom_release_buffer(buf);
 }

--- a/soracom/orbit.c
+++ b/soracom/orbit.c
@@ -129,7 +129,7 @@ int32_t soracom_get_source_value(const char* name, size_t name_len, const char**
  * @param buf [out] A pointer to the allocated memory.
  * @param siz [out] The length of the string.
  *
- * @note The pointer received in buf should be released by calling soracom_release_userdata().
+ * @note The pointer received in buf should be released by calling soracom_release_buffer().
  *
  * @return ERR_OK: successfully retrieved the userdata.
  *         ERR_INVALID_ARG: buf or siz is null.
@@ -147,14 +147,54 @@ int32_t soracom_get_userdata_as_string(const char** buf, size_t* siz) {
 }
 
 /**
+ * Get the original request as a null terminated string.
+ *
+ * @param buf [out] A pointer to the allocated memory.
+ * @param siz [out] The length of the string.
+ *
+ * @note The pointer received in buf should be released by calling soracom_release_buffer().
+ *
+ * @return ERR_OK: successfully retrieved the userdata.
+ *         ERR_INVALID_ARG: buf or siz is null.
+ */
+
+int32_t soracom_get_original_request_as_string(const char** buf, size_t* siz) {
+    if ((buf == NULL) || (siz == NULL)) {
+        return ERR_INVALID_ARG;
+    }
+
+    *siz = orbit_get_original_request_len();
+    *buf = (const char*) malloc(*siz + 1);
+    memset((void*)(*buf), 0, *siz + 1);
+    orbit_get_original_request(*buf, *siz);
+    return ERR_OK;
+}
+
+
+/**
+ * Release the buffer memory.
+ *
+ * @param buf [in] The pointer to the allocated
+ *
+ * @note The pointer buf is allocated by 
+ * - soracom_get_userdata_as_string().
+ * - soracom_get_original_request_as_string().
+ */
+void soracom_release_buffer(const char* buf) {
+    free((void*)(buf));
+}
+
+/**
  * Release the userdata.
  *
  * @param buf [in] The pointer to the allocated userdata.
  *
  * @note The pointer buf is allocated by soracom_get_userdata_as_string().
+ * @deprecated Use soracom_release_buffer instead
+ * 
  */
 void soracom_release_userdata(const char* buf) {
-    free((void*)(buf));
+    soracom_release_buffer(buf);
 }
 
 /**

--- a/soracom/orbit.h
+++ b/soracom/orbit.h
@@ -1,50 +1,50 @@
 #ifndef __SORACOM_ORBIT_SDK__ORBIT_H__
 #define __SORACOM_ORBIT_SDK__ORBIT_H__
 
-#define ERR_OK (0)
+#define ERR_OK          (0)
 #define ERR_INVALID_ARG (-1)
 
 #if __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 #include <stddef.h>
 #include <stdint.h>
 
-    void orbit_log(const char *message, size_t siz);
-    size_t orbit_get_input_buffer_len();
-    size_t orbit_get_input_buffer(const char *buf, size_t siz);
-    size_t orbit_get_tag_value_len(const char *name, size_t name_len);
-    size_t orbit_get_tag_value(const char *name, size_t name_len, const char *value, size_t value_len);
-    size_t orbit_get_source_value_len(const char *name, size_t name_len);
-    size_t orbit_get_source_value(const char *name, size_t name_len, const char *value, size_t value_len);
-    size_t orbit_get_userdata_len();
-    size_t orbit_get_userdata(const char *value, size_t value_len);
-    size_t orbit_get_original_request_len();
-    size_t orbit_get_original_request(const char *value, size_t value_len);
-    int32_t orbit_has_location();
-    double orbit_get_location_lat();
-    double orbit_get_location_lon();
-    int64_t orbit_get_timestamp();
-    void orbit_set_output(const char *buf, size_t siz);
-    void orbit_set_output_content_type(const char *buf, size_t siz);
+void orbit_log(const char* message, size_t siz);
+size_t orbit_get_input_buffer_len();
+size_t orbit_get_input_buffer(const char* buf, size_t siz);
+size_t orbit_get_tag_value_len(const char* name, size_t name_len);
+size_t orbit_get_tag_value(const char* name, size_t name_len, const char* value, size_t value_len);
+size_t orbit_get_source_value_len(const char* name, size_t name_len);
+size_t orbit_get_source_value(const char* name, size_t name_len, const char* value, size_t value_len);
+size_t orbit_get_userdata_len();
+size_t orbit_get_userdata(const char* value, size_t value_len);
+size_t orbit_get_original_request_len();
+size_t orbit_get_original_request(const char* value, size_t value_len);
+int32_t orbit_has_location();
+double orbit_get_location_lat();
+double orbit_get_location_lon();
+int64_t orbit_get_timestamp();
+void orbit_set_output(const char* buf, size_t siz);
+void orbit_set_output_content_type(const char* buf, size_t siz);
 
-    void soracom_log(const char *fmt, ...);
-    int32_t soracom_get_input_buffer_as_string(const char **buf, size_t *siz);
-    int32_t soracom_get_input_buffer(const char **buf, size_t *siz);
-    [[deprecated("Use soracom_release_buffer instead")]]
-    void soracom_release_input_buffer(const char *buf);
-    int32_t soracom_get_tag_value(const char *name, size_t name_len, const char **value, size_t *value_len);
-    int32_t soracom_get_source_value(const char *name, size_t name_len, const char **value, size_t *value_len);
-    int32_t soracom_get_userdata_as_string(const char **buf, size_t *siz);
-    void soracom_set_json_output(const char *buf, size_t siz);
+void soracom_log(const char* fmt, ...);
+int32_t soracom_get_input_buffer_as_string(const char** buf, size_t* siz);
+int32_t soracom_get_input_buffer(const char** buf, size_t* siz);
+int32_t soracom_get_tag_value(const char* name, size_t name_len, const char** value, size_t* value_len);
+int32_t soracom_get_source_value(const char* name, size_t name_len, const char** value, size_t* value_len);
+int32_t soracom_get_userdata_as_string(const char** buf, size_t* siz);
+void soracom_set_json_output(const char* buf, size_t siz);
 
-    [[deprecated("Use soracom_release_buffer instead")]]
-    void soracom_release_userdata(const char *buf);
+[[deprecated("Use soracom_release_buffer instead")]]
+void soracom_release_input_buffer(const char* buf);
+[[deprecated("Use soracom_release_buffer instead")]]
+void soracom_release_userdata(const char* buf);
 
 #if __cplusplus
 }
 #endif
+
 
 #endif /* __SORACOM_ORBIT_SDK__ORBIT_H__ */

--- a/soracom/orbit.h
+++ b/soracom/orbit.h
@@ -20,6 +20,8 @@ size_t orbit_get_source_value_len(const char* name, size_t name_len);
 size_t orbit_get_source_value(const char* name, size_t name_len, const char* value, size_t value_len);
 size_t orbit_get_userdata_len();
 size_t orbit_get_userdata(const char* value, size_t value_len);
+size_t orbit_get_original_request_len();
+size_t orbit_get_original_request(const char* value, size_t value_len);
 int32_t orbit_has_location();
 double orbit_get_location_lat();
 double orbit_get_location_lon();

--- a/soracom/orbit.h
+++ b/soracom/orbit.h
@@ -1,49 +1,50 @@
 #ifndef __SORACOM_ORBIT_SDK__ORBIT_H__
 #define __SORACOM_ORBIT_SDK__ORBIT_H__
 
-#define ERR_OK          (0)
+#define ERR_OK (0)
 #define ERR_INVALID_ARG (-1)
 
 #if __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <stddef.h>
 #include <stdint.h>
 
-void orbit_log(const char* message, size_t siz);
-size_t orbit_get_input_buffer_len();
-size_t orbit_get_input_buffer(const char* buf, size_t siz);
-size_t orbit_get_tag_value_len(const char* name, size_t name_len);
-size_t orbit_get_tag_value(const char* name, size_t name_len, const char* value, size_t value_len);
-size_t orbit_get_source_value_len(const char* name, size_t name_len);
-size_t orbit_get_source_value(const char* name, size_t name_len, const char* value, size_t value_len);
-size_t orbit_get_userdata_len();
-size_t orbit_get_userdata(const char* value, size_t value_len);
-size_t orbit_get_original_request_len();
-size_t orbit_get_original_request(const char* value, size_t value_len);
-int32_t orbit_has_location();
-double orbit_get_location_lat();
-double orbit_get_location_lon();
-int64_t orbit_get_timestamp();
-void orbit_set_output(const char* buf, size_t siz);
-void orbit_set_output_content_type(const char* buf, size_t siz);
+    void orbit_log(const char *message, size_t siz);
+    size_t orbit_get_input_buffer_len();
+    size_t orbit_get_input_buffer(const char *buf, size_t siz);
+    size_t orbit_get_tag_value_len(const char *name, size_t name_len);
+    size_t orbit_get_tag_value(const char *name, size_t name_len, const char *value, size_t value_len);
+    size_t orbit_get_source_value_len(const char *name, size_t name_len);
+    size_t orbit_get_source_value(const char *name, size_t name_len, const char *value, size_t value_len);
+    size_t orbit_get_userdata_len();
+    size_t orbit_get_userdata(const char *value, size_t value_len);
+    size_t orbit_get_original_request_len();
+    size_t orbit_get_original_request(const char *value, size_t value_len);
+    int32_t orbit_has_location();
+    double orbit_get_location_lat();
+    double orbit_get_location_lon();
+    int64_t orbit_get_timestamp();
+    void orbit_set_output(const char *buf, size_t siz);
+    void orbit_set_output_content_type(const char *buf, size_t siz);
 
-void soracom_log(const char* fmt, ...);
-int32_t soracom_get_input_buffer_as_string(const char** buf, size_t* siz);
-int32_t soracom_get_input_buffer(const char** buf, size_t* siz);
-void soracom_release_input_buffer(const char* buf);
-int32_t soracom_get_tag_value(const char* name, size_t name_len, const char** value, size_t* value_len);
-int32_t soracom_get_source_value(const char* name, size_t name_len, const char** value, size_t* value_len);
-int32_t soracom_get_userdata_as_string(const char** buf, size_t* siz);
-void soracom_set_json_output(const char* buf, size_t siz);
+    void soracom_log(const char *fmt, ...);
+    int32_t soracom_get_input_buffer_as_string(const char **buf, size_t *siz);
+    int32_t soracom_get_input_buffer(const char **buf, size_t *siz);
+    [[deprecated("Use soracom_release_buffer instead")]]
+    void soracom_release_input_buffer(const char *buf);
+    int32_t soracom_get_tag_value(const char *name, size_t name_len, const char **value, size_t *value_len);
+    int32_t soracom_get_source_value(const char *name, size_t name_len, const char **value, size_t *value_len);
+    int32_t soracom_get_userdata_as_string(const char **buf, size_t *siz);
+    void soracom_set_json_output(const char *buf, size_t siz);
 
-[[deprecated("Use soracom_release_buffer instead")]]
-void soracom_release_userdata(const char* buf);
+    [[deprecated("Use soracom_release_buffer instead")]]
+    void soracom_release_userdata(const char *buf);
 
 #if __cplusplus
 }
 #endif
-
 
 #endif /* __SORACOM_ORBIT_SDK__ORBIT_H__ */

--- a/soracom/orbit.h
+++ b/soracom/orbit.h
@@ -36,8 +36,10 @@ void soracom_release_input_buffer(const char* buf);
 int32_t soracom_get_tag_value(const char* name, size_t name_len, const char** value, size_t* value_len);
 int32_t soracom_get_source_value(const char* name, size_t name_len, const char** value, size_t* value_len);
 int32_t soracom_get_userdata_as_string(const char** buf, size_t* siz);
-void soracom_release_userdata(const char* buf);
 void soracom_set_json_output(const char* buf, size_t siz);
+
+[[deprecated("Use soracom_release_buffer instead")]]
+void soracom_release_userdata(const char* buf);
 
 #if __cplusplus
 }


### PR DESCRIPTION
## Description

Added a function for getting original request sent to Unified Endpoint via`int32_t soracom_get_original_request_as_string` function

reference: 
https://github.com/soracom/orbit-sdk-rust/pull/2


## Others
- deprecate soracom_release_userdata, use soracom_release_buffer instead